### PR TITLE
Removed stat_file on load_session, improves startup speed also.

### DIFF
--- a/saverestorestate/saverestorestate.sl
+++ b/saverestorestate/saverestorestate.sl
@@ -152,6 +152,7 @@ private define dedupe (sessionfile)
 		    || (1 != sscanf(fields[3], "0x%x", &flags)))
 			throw DataError, "session file appears corrupt";
 		file = fields[0];
+		% Okay to do this here, on exit.
 		if (NULL == stat_file (file))
 			continue;
 		files[file] = fields;
@@ -260,9 +261,6 @@ private define load_session ()
 			throw DataError, "session file appears corrupt";
 
 		file = fields[0];
-
-		if (NULL == stat_file (file))
-			continue;
 
 		if (strcmp (file,expand_filename(__argv[1])) != 0)
 			continue;


### PR DESCRIPTION
If the .jedsession file grows large a stat of every file is not good for performance. The impact is seen at startup. The dedupe func retains the stat call to keep .jedsession file clean of files that no longer exist also.
